### PR TITLE
Implement state management 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,6 +2401,7 @@ dependencies = [
  "log",
  "mint",
  "once_cell",
+ "paste",
  "rayon",
  "serde",
  "shaderc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,12 +2320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tobj"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468f55be8e59cf7219f1685cf1af4eb00ef2314823a7941a41c8d69538f881b"
-
-[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2397,6 +2391,7 @@ dependencies = [
  "egui",
  "env_logger",
  "futures",
+ "fxhash",
  "glam",
  "glob",
  "gltf",
@@ -2409,7 +2404,6 @@ dependencies = [
  "rayon",
  "serde",
  "shaderc",
- "tobj",
  "wgpu",
  "winit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,10 @@ serde = {version = "1", features = ["derive"]}
 gltf = "0.15"
 fxhash = "0.2"
 
+
 [dev-dependencies]
 criterion = "0.3"
+paste = "1"
 
 [[bench]]
 name = "intersection_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ wgpu = "0.7"
 log = "0.4"
 legion = "0.4" 
 crevice = "0.6"
-tobj = "2"
 bytemuck = {version = "1.5", features = ["derive"]}
 image = "0.23"
 once_cell = "1"
@@ -44,6 +43,7 @@ laminar = "0.4"
 bincode = "1.3"
 serde = {version = "1", features = ["derive"]}
 gltf = "0.15"
+fxhash = "0.2"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/bin/client/assets.rs
+++ b/src/bin/client/assets.rs
@@ -2,10 +2,11 @@ use anyhow::Result;
 use legion::*;
 use log::{error, info};
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{ VecDeque},
     marker::PhantomData,
     sync::atomic::Ordering,
 };
+use fxhash::FxHashMap;
 use std::{
     fmt::Debug,
     hash::Hash,
@@ -55,14 +56,14 @@ pub trait AssetLoader: Sized {
 }
 
 pub struct Assets<T: AssetLoader> {
-    storage: HashMap<Handle<T>, T>,
+    storage: FxHashMap<Handle<T>, T>,
     gpu_load_queue: VecDeque<(Handle<T>, PathBuf)>,
 }
 
 impl<T: AssetLoader> Assets<T> {
     pub fn new() -> Assets<T> {
         Assets {
-            storage: HashMap::default(),
+            storage: FxHashMap::default(),
             gpu_load_queue: VecDeque::default(),
         }
     }
@@ -93,7 +94,7 @@ impl<T: AssetLoader> Assets<T> {
     #[inline]
     fn clear_load_queue_impl(
         load_queue: &VecDeque<(Handle<T>, PathBuf)>,
-        storage: &mut HashMap<Handle<T>, T>,
+        storage: &mut FxHashMap<Handle<T>, T>,
         device: &Device,
         queue: &Queue,
     ) -> Result<()> {

--- a/src/bin/client/assets.rs
+++ b/src/bin/client/assets.rs
@@ -1,12 +1,8 @@
 use anyhow::Result;
+use fxhash::FxHashMap;
 use legion::*;
 use log::{error, info};
-use std::{
-    collections::{ VecDeque},
-    marker::PhantomData,
-    sync::atomic::Ordering,
-};
-use fxhash::FxHashMap;
+use std::{collections::VecDeque, marker::PhantomData, sync::atomic::Ordering};
 use std::{
     fmt::Debug,
     hash::Hash,

--- a/src/bin/client/client_systems.rs
+++ b/src/bin/client/client_systems.rs
@@ -3,10 +3,7 @@ use std::net::SocketAddr;
 use crate::{
     assets::{Assets, Handle},
     graphics::{
-        camera::Camera,
-        gltf::GltfModel,
-        heightmap_pass::HeightMap,
-        ui::ui_context::{UiContext, WindowSize},
+        camera::Camera, gltf::GltfModel, heightmap_pass::HeightMap, ui::ui_context::UiContext,
     },
     input::{CursorPosition, MouseButtonState},
 };

--- a/src/bin/client/engine.rs
+++ b/src/bin/client/engine.rs
@@ -2,10 +2,7 @@ use std::{any::TypeId, time::Instant};
 
 use crate::{client_network::handle_server_update, state::State};
 use crate::{
-    graphics::ui::{
-        ui_context::{UiContext},
-        ui_pass, ui_systems,
-    },
+    graphics::ui::{ui_context::UiContext, ui_pass, ui_systems},
     input::{self, KeyboardState, MouseButtonState, MouseMotion, Text},
 };
 use crossbeam_channel::{Receiver, Sender};

--- a/src/bin/client/engine.rs
+++ b/src/bin/client/engine.rs
@@ -1,4 +1,3 @@
-use std::{ time::Instant};
 use crate::{client_network::handle_server_update, state::State};
 use crate::{
     graphics::ui::{ui_context::UiContext, ui_pass, ui_systems},
@@ -8,6 +7,7 @@ use crate::{
 use crossbeam_channel::{Receiver, Sender};
 use input::CursorPosition;
 use legion::{systems::Step, *};
+use std::time::Instant;
 use unnamed_rts::resources::{Time, WindowSize};
 use wgpu::{
     BackendBit, CommandBuffer, Device, DeviceDescriptor, Features, Instance, Limits,
@@ -21,8 +21,6 @@ use winit::{
     },
     window::{Window, WindowId},
 };
-
-
 
 pub struct Engine {
     world: World,
@@ -127,7 +125,8 @@ impl Engine {
         let state = crate::state::GameState {};
         let mut command_receivers = vec![];
         let mut state_stack = StateStack::default();
-        let mut state_steps = state_stack.push(state, &mut world, &mut resources, &mut command_receivers);
+        let mut state_steps =
+            state_stack.push(state, &mut world, &mut resources, &mut command_receivers);
         command_receivers.push(ui_rc);
 
         let mut all_steps =
@@ -312,7 +311,7 @@ impl Engine {
     pub fn render(&mut self) -> Result<(), wgpu::SwapChainError> {
         // move this somewhere else:
         let mut time = self.resources.get_mut::<Time>().unwrap();
-        let now = std::time::Instant::now();
+        let now = Instant::now();
         time.delta_time = (now - time.current_time).as_secs_f32();
         time.current_time = now;
         drop(time);

--- a/src/bin/client/graphics/camera.rs
+++ b/src/bin/client/graphics/camera.rs
@@ -4,10 +4,9 @@ use crevice::std430::Std430;
 use glam::*;
 use legion::*;
 use once_cell::sync::OnceCell;
-use unnamed_rts::resources::Time;
+use unnamed_rts::resources::{Time, WindowSize};
 use winit::event::{MouseButton, VirtualKeyCode};
 
-use super::ui::ui_context::WindowSize;
 #[derive(Debug)]
 pub struct Camera {
     direction: Vec3A,

--- a/src/bin/client/graphics/common.rs
+++ b/src/bin/client/graphics/common.rs
@@ -8,19 +8,19 @@ pub struct DepthTexture {
 }
 
 impl DepthTexture {
-    pub fn new(device: &wgpu::Device, sc_desc: &wgpu::SwapChainDescriptor) -> DepthTexture {
-        let desc = Self::create_texture_descriptor(sc_desc);
+    pub fn new(device: &wgpu::Device, width: u32, height: u32) -> DepthTexture {
+        let desc = Self::create_texture_descriptor(width, height);
         let texture = device.create_texture(&desc);
         let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
         DepthTexture { texture, view }
     }
 
-    fn create_texture_descriptor(sc_desc: &wgpu::SwapChainDescriptor) -> wgpu::TextureDescriptor {
+    fn create_texture_descriptor(width: u32, height: u32) -> wgpu::TextureDescriptor<'static> {
         wgpu::TextureDescriptor {
             label: Some("Depth texture"),
             size: wgpu::Extent3d {
-                width: sc_desc.width,
-                height: sc_desc.height,
+                width,
+                height,
                 depth: 1,
             },
             mip_level_count: 1,
@@ -31,8 +31,8 @@ impl DepthTexture {
         }
     }
 
-    pub fn resize(&mut self, device: &wgpu::Device, sc_desc: &wgpu::SwapChainDescriptor) {
-        self.texture = device.create_texture(&Self::create_texture_descriptor(sc_desc));
+    pub fn resize(&mut self, device: &wgpu::Device, width: u32, height: u32) {
+        self.texture = device.create_texture(&Self::create_texture_descriptor(width, height));
         self.view = self
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());

--- a/src/bin/client/graphics/debug_lines_pass.rs
+++ b/src/bin/client/graphics/debug_lines_pass.rs
@@ -51,7 +51,7 @@ pub fn update_bounding_boxes(
 #[system]
 pub fn draw(
     world: &SubWorld,
-    #[state] pass: &DebugLinesPass,
+    #[resource] pass: &DebugLinesPass,
     #[resource] bounding_box_map: &BoundingBoxMap,
     #[resource] device: &wgpu::Device,
     #[resource] depth_texture: &DepthTexture,

--- a/src/bin/client/graphics/debug_lines_pass.rs
+++ b/src/bin/client/graphics/debug_lines_pass.rs
@@ -12,7 +12,7 @@ use crate::{
 use crossbeam_channel::Sender;
 use glam::Vec3;
 use legion::*;
-use std::collections::HashMap;
+use fxhash::FxHashMap;
 use unnamed_rts::components::Transform;
 use wgpu::{include_spirv, SwapChainTexture};
 use world::SubWorld;
@@ -20,7 +20,7 @@ use world::SubWorld;
 #[derive(Debug, Default)]
 // This should be refactored to be component based instead of using this resource
 pub struct BoundingBoxMap {
-    vertex_info_map: HashMap<Handle<GltfModel>, ImmutableVertexData<BoxVert>>,
+    vertex_info_map: FxHashMap<Handle<GltfModel>, ImmutableVertexData<BoxVert>>,
 }
 
 #[system]

--- a/src/bin/client/graphics/debug_lines_pass.rs
+++ b/src/bin/client/graphics/debug_lines_pass.rs
@@ -10,9 +10,9 @@ use crate::{
     client_systems::DebugMenueSettings,
 };
 use crossbeam_channel::Sender;
+use fxhash::FxHashMap;
 use glam::Vec3;
 use legion::*;
-use fxhash::FxHashMap;
 use unnamed_rts::components::Transform;
 use wgpu::{include_spirv, SwapChainTexture};
 use world::SubWorld;

--- a/src/bin/client/graphics/grid_pass.rs
+++ b/src/bin/client/graphics/grid_pass.rs
@@ -10,7 +10,7 @@ use wgpu::include_spirv;
 
 #[system]
 pub fn draw(
-    #[state] pass: &GridPass,
+    #[resource] pass: &GridPass,
     #[resource] debug_settings: &DebugMenueSettings,
     #[resource] device: &wgpu::Device,
     #[resource] depth_texture: &DepthTexture,

--- a/src/bin/client/graphics/heightmap_pass.rs
+++ b/src/bin/client/graphics/heightmap_pass.rs
@@ -296,7 +296,7 @@ pub fn update(#[resource] queue: &wgpu::Queue, #[resource] height_map: &mut Heig
 
 #[system]
 pub fn draw(
-    #[state] pass: &HeightMapPass,
+    #[resource] pass: &HeightMapPass,
     #[resource] current_frame: &wgpu::SwapChainTexture,
     #[resource] device: &wgpu::Device,
     #[resource] depth_texture: &DepthTexture,

--- a/src/bin/client/graphics/model_pass.rs
+++ b/src/bin/client/graphics/model_pass.rs
@@ -42,7 +42,7 @@ pub fn update(
 #[system]
 pub fn draw(
     world: &SubWorld,
-    #[state] pass: &ModelPass,
+    #[resource] pass: &ModelPass,
     #[resource] asset_storage: &Assets<GltfModel>,
     #[resource] depth_texture: &DepthTexture,
     #[resource] device: &wgpu::Device,

--- a/src/bin/client/graphics/selection_pass.rs
+++ b/src/bin/client/graphics/selection_pass.rs
@@ -17,7 +17,7 @@ use super::common::DepthTexture;
 #[allow(clippy::clippy::too_many_arguments)]
 pub fn draw(
     world: &SubWorld,
-    #[state] pass: &SelectionPass,
+    #[resource] pass: &SelectionPass,
     #[resource] queue: &wgpu::Queue,
     #[resource] asset_storage: &Assets<GltfModel>,
     #[resource] depth_texture: &DepthTexture,

--- a/src/bin/client/graphics/ui/ui_context.rs
+++ b/src/bin/client/graphics/ui/ui_context.rs
@@ -1,20 +1,7 @@
 use egui::{paint::ClippedShape, vec2, CtxRef, RawInput};
+use unnamed_rts::resources::WindowSize;
 use winit::event::ModifiersState;
 
-#[derive(Debug, Clone, Copy)]
-pub struct WindowSize {
-    pub physical_width: u32,
-    pub physical_height: u32,
-    pub scale_factor: f32,
-}
-
-impl WindowSize {
-    pub fn logical_size(&self) -> (u32, u32) {
-        let logical_width = self.physical_width as f32 / self.scale_factor;
-        let logical_height = self.physical_height as f32 / self.scale_factor;
-        (logical_width as u32, logical_height as u32)
-    }
-}
 
 pub struct CursorPosition {
     pub x: f64,

--- a/src/bin/client/graphics/ui/ui_context.rs
+++ b/src/bin/client/graphics/ui/ui_context.rs
@@ -2,7 +2,6 @@ use egui::{paint::ClippedShape, vec2, CtxRef, RawInput};
 use unnamed_rts::resources::WindowSize;
 use winit::event::ModifiersState;
 
-
 pub struct CursorPosition {
     pub x: f64,
     pub y: f64,

--- a/src/bin/client/graphics/ui/ui_pass.rs
+++ b/src/bin/client/graphics/ui/ui_pass.rs
@@ -7,7 +7,6 @@ use wgpu::{
     CommandBuffer, Device,
 };
 
-
 #[derive(Debug)]
 enum BufferType {
     Uniform,

--- a/src/bin/client/graphics/ui/ui_pass.rs
+++ b/src/bin/client/graphics/ui/ui_pass.rs
@@ -1,12 +1,12 @@
 use bytemuck::{Pod, Zeroable};
 use crossbeam_channel::Sender;
+use unnamed_rts::resources::WindowSize;
 use wgpu::{
     include_spirv,
     util::{BufferInitDescriptor, DeviceExt},
     CommandBuffer, Device,
 };
 
-use super::ui_context::WindowSize;
 
 #[derive(Debug)]
 enum BufferType {

--- a/src/bin/client/graphics/ui/ui_systems.rs
+++ b/src/bin/client/graphics/ui/ui_systems.rs
@@ -3,14 +3,14 @@ use std::time::Instant;
 use egui::{pos2, vec2};
 use input::{CursorPosition, Text};
 use legion::*;
-use unnamed_rts::resources::Time;
+use unnamed_rts::resources::{Time, WindowSize};
 use wgpu::{CommandEncoderDescriptor, Device, Queue, SwapChainTexture};
 use winit::event::{ModifiersState, MouseButton, MouseScrollDelta};
 
 use crate::input::{self, EventReader};
 
 use super::{
-    ui_context::{UiContext, WindowSize},
+    ui_context::{UiContext},
     ui_pass::UiPass,
 };
 

--- a/src/bin/client/graphics/ui/ui_systems.rs
+++ b/src/bin/client/graphics/ui/ui_systems.rs
@@ -9,10 +9,7 @@ use winit::event::{ModifiersState, MouseButton, MouseScrollDelta};
 
 use crate::input::{self, EventReader};
 
-use super::{
-    ui_context::{UiContext},
-    ui_pass::UiPass,
-};
+use super::{ui_context::UiContext, ui_pass::UiPass};
 
 #[allow(clippy::clippy::too_many_arguments)]
 #[system]

--- a/src/bin/client/main.rs
+++ b/src/bin/client/main.rs
@@ -1,4 +1,4 @@
-use application::App;
+use engine::Engine;
 use futures::executor::block_on;
 use log::warn;
 use winit::{
@@ -7,7 +7,7 @@ use winit::{
     window::WindowBuilder,
 };
 
-mod application;
+mod engine;
 mod assets;
 mod state;
 mod client_network;
@@ -25,7 +25,7 @@ fn main() {
         .with_title("RTS!")
         .build(&event_loop)
         .expect("Failed to create window");
-    let mut app = block_on(App::new(&window));
+    let mut app = block_on(Engine::new(&window));
     event_loop.run(move |event, _, control_flow| {
         if !app.event_handler(&event, &window.id()) {
             match event {

--- a/src/bin/client/main.rs
+++ b/src/bin/client/main.rs
@@ -1,6 +1,7 @@
 use engine::Engine;
 use futures::executor::block_on;
-use log::warn;
+#[macro_use]
+extern crate log;
 use winit::{
     event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -14,6 +15,7 @@ mod engine;
 mod graphics;
 mod input;
 mod state;
+mod state_stack;
 
 fn main() {
     env_logger::builder()

--- a/src/bin/client/main.rs
+++ b/src/bin/client/main.rs
@@ -9,6 +9,7 @@ use winit::{
 
 mod application;
 mod assets;
+mod state;
 mod client_network;
 mod client_systems;
 mod graphics;

--- a/src/bin/client/main.rs
+++ b/src/bin/client/main.rs
@@ -7,13 +7,13 @@ use winit::{
     window::WindowBuilder,
 };
 
-mod engine;
 mod assets;
-mod state;
 mod client_network;
 mod client_systems;
+mod engine;
 mod graphics;
 mod input;
+mod state;
 
 fn main() {
     env_logger::builder()

--- a/src/bin/client/state.rs
+++ b/src/bin/client/state.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use core::fmt::Debug;
 use crossbeam_channel::Receiver;
 use glam::{Quat, Vec3};
@@ -39,8 +40,8 @@ pub trait State: Debug {
         resources: &mut Resources,
         command_receivers: &mut Vec<Receiver<CommandBuffer>>,
     );
-
-    fn on_tick(&mut self) -> StateTransition;
+    // Only called when in foreground 
+    fn on_foreground_tick(&mut self) -> StateTransition;
     fn on_resize(&mut self, resources: &mut Resources, new_size: &WindowSize) {}
     // Todo: clean up command receivers?
     fn on_destroy(&mut self, world: &mut World, resources: &mut Resources);
@@ -138,7 +139,7 @@ impl State for GameState {
         resources.insert(camera);
     }
 
-    fn on_tick(&mut self) -> StateTransition {
+    fn on_foreground_tick(&mut self) -> StateTransition {
         StateTransition::Noop
     }
 

--- a/src/bin/client/state.rs
+++ b/src/bin/client/state.rs
@@ -1,10 +1,13 @@
-use std::{borrow::Cow, f32::consts::PI, time::Instant};
 use core::fmt::Debug;
 use crossbeam_channel::Receiver;
 use glam::{Quat, Vec3};
 use image::GenericImageView;
 use legion::*;
-use unnamed_rts::{components::Transform, resources::{NetworkSerialization, WindowSize}};
+use std::{borrow::Cow, f32::consts::PI, time::Instant};
+use unnamed_rts::{
+    components::Transform,
+    resources::{NetworkSerialization, WindowSize},
+};
 use wgpu::{CommandBuffer, Device, Queue};
 
 use crate::{
@@ -21,7 +24,7 @@ use crate::{
         lights::{self, LightUniformBuffer},
         model_pass, selection_pass,
         texture::TextureContent,
-        ui::{ ui_pass::UiPass, ui_systems},
+        ui::{ui_pass::UiPass, ui_systems},
     },
     input,
 };

--- a/src/bin/client/state.rs
+++ b/src/bin/client/state.rs
@@ -1,0 +1,193 @@
+use std::{borrow::Cow, f32::consts::PI, time::Instant};
+
+use crossbeam_channel::Receiver;
+use glam::{Quat, Vec3};
+use image::GenericImageView;
+use legion::*;
+use unnamed_rts::components::Transform;
+use wgpu::{CommandBuffer, Device, Queue};
+
+use crate::{
+    assets::{self, Assets},
+    client_network::{add_client_components, connect_to_server},
+    client_systems::{self, DebugMenueSettings},
+    graphics::{
+        camera::{self, Camera},
+        debug_lines_pass::{self, BoundingBoxMap},
+        gltf::GltfModel,
+        grid_pass,
+        heightmap_pass::{self, HeightMap},
+        lights::{self, LightUniformBuffer},
+        model_pass, selection_pass,
+        texture::TextureContent,
+        ui::{ui_context::WindowSize, ui_pass::UiPass, ui_systems},
+    },
+    input,
+};
+
+pub enum StateTransition {
+    Pop,
+    Push(Box<dyn State>),
+}
+pub trait State {
+    fn on_init(
+        &mut self,
+        world: &mut World,
+        resources: &mut Resources,
+    );
+    fn on_update(&mut self) -> Option<StateTransition>;
+    fn on_destroy(&mut self);
+    fn on_backgrouded(
+        &mut self,
+        world: &mut World,
+        resources: &mut Resources,
+        command_receivers: &mut Vec<Receiver<CommandBuffer>>,
+    ) -> Schedule;
+    fn on_forgrounded(
+        &mut self,
+        world: &mut World,
+        resources: &mut Resources,
+        command_receivers: &mut Vec<Receiver<CommandBuffer>>,
+    ) -> Schedule;
+}
+
+#[derive(Debug)]
+pub struct GameState {}
+
+impl State for GameState {
+    fn on_init(
+        &mut self,
+        world: &mut World,
+        resources: &mut Resources,
+    ) {
+        resources.insert(BoundingBoxMap::default());
+        let size = resources
+            .get::<WindowSize>()
+            .expect("Window size to be present");
+        let device = resources.get::<Device>().expect("Device to be present");
+        let mut assets = resources
+            .get_mut::<Assets<GltfModel>>()
+            .expect("GltfAsset storage to be present");
+        let queue = resources.get::<Queue>().expect("Queue to be present");
+        let camera = Camera::new(
+            &device,
+            Vec3::new(0., 2., 3.5),
+            Vec3::new(0.0, 0.0, -1.0),
+            size.physical_width,
+            size.physical_height,
+        );
+        let light_uniform = LightUniformBuffer::new(&device);
+        let img = image::io::Reader::open("assets/HeightMapExample.jpg")
+            .unwrap()
+            .decode()
+            .unwrap();
+        let texture = TextureContent {
+            label: Some("Displacement map"),
+            format: wgpu::TextureFormat::R8Unorm,
+            bytes: Cow::Owned(img.as_luma8().expect("Grayscale displacement map").to_vec()),
+            stride: 1,
+            size: wgpu::Extent3d {
+                width: img.width(),
+                height: img.height(),
+                depth: 1,
+            },
+        };
+        let mut transform = Transform::from_position(Vec3::new(0.0, 0.0, 0.0));
+        transform.scale = Vec3::splat(0.1);
+        transform.rotation = Quat::from_rotation_x(PI / 2.0);
+
+        // Set up network and connect to server
+        let suit = assets.load("FlightHelmet/FlightHelmet.gltf").unwrap();
+        let height_map = HeightMap::from_displacement_map(&device, &queue, 256, texture, transform);
+        drop(device);
+        drop(assets);
+        drop(size);
+        drop(queue);
+        connect_to_server(world, resources);
+        add_client_components(world, resources, &suit);
+
+        resources.insert(height_map);
+        resources.insert(DebugMenueSettings {
+            show_grid: true,
+            show_bounding_boxes: true,
+        });
+        resources.insert(light_uniform);
+        resources.insert(camera);
+    }
+
+    fn on_update(&mut self) -> Option<StateTransition> {
+        None
+    }
+
+    fn on_destroy(&mut self) {
+        todo!()
+    }
+
+    fn on_backgrouded(
+        &mut self,
+        world: &mut World,
+        resources: &mut Resources,
+        command_receivers: &mut Vec<Receiver<CommandBuffer>>,
+    ) -> Schedule {
+        todo!()
+    }
+
+    fn on_forgrounded(
+        &mut self,
+        world: &mut World,
+        resources: &mut Resources,
+        command_receivers: &mut Vec<Receiver<CommandBuffer>>,
+    ) -> Schedule {
+        let (ui_sender, ui_rc) = crossbeam_channel::bounded(1);
+        let (debug_sender, debug_rc) = crossbeam_channel::bounded(1);
+        let (model_sender, model_rc) = crossbeam_channel::bounded(1);
+        let (heightmap_sender, heightmap_rc) = crossbeam_channel::bounded(1);
+        let (lines_sender, lines_rc) = crossbeam_channel::bounded(1);
+        let (selectable_sender, selectable_rc) = crossbeam_channel::bounded(1);
+        command_receivers.push(model_rc);
+        command_receivers.push(heightmap_rc);
+        command_receivers.push(selectable_rc);
+        command_receivers.push(debug_rc);
+        command_receivers.push(lines_rc);
+        command_receivers.push(ui_rc); 
+        let device = resources.get::<Device>().expect("Device to be present");
+        Schedule::builder()
+            .add_system(assets::asset_load_system::<GltfModel>())
+            .add_system(camera::free_flying_camera_system())
+            .add_system(model_pass::update_system())
+            .add_system(lights::update_system())
+            .add_system(model_pass::draw_system(model_pass::ModelPass::new(
+                &device,
+                model_sender,
+            )))
+            .add_system(selection_pass::draw_system(
+                selection_pass::SelectionPass::new(&device, selectable_sender),
+            ))
+            .add_system(client_systems::height_map_modification_system())
+            .add_system(heightmap_pass::update_system())
+            .add_system(heightmap_pass::draw_system(
+                heightmap_pass::HeightMapPass::new(&device, heightmap_sender),
+            ))
+            .add_system(ui_systems::update_ui_system())
+            .add_system(client_systems::selection_system())
+            .add_system(grid_pass::draw_system(grid_pass::GridPass::new(
+                &device,
+                debug_sender,
+            )))
+            .add_system(debug_lines_pass::update_bounding_boxes_system())
+            .add_system(debug_lines_pass::draw_system(
+                debug_lines_pass::DebugLinesPass::new(&device, lines_sender),
+            ))
+            // THIS SHOULDN'T BE HERE
+            .add_system(ui_systems::begin_ui_frame_system(Instant::now()))
+            .add_system(client_systems::draw_debug_ui_system())
+            // THIS SHOULDN'T BE HERE
+            .add_system(ui_systems::end_ui_frame_system(UiPass::new(
+                &device, ui_sender,
+            )))
+            .add_system(client_systems::move_action_system())
+            // THIS SHOULDN'T BE HERE
+            .add_system(input::event_system())
+            .build()
+    }
+}

--- a/src/bin/client/state_stack.rs
+++ b/src/bin/client/state_stack.rs
@@ -1,0 +1,284 @@
+use crate::state::State;
+use crossbeam_channel::Receiver;
+use legion::{systems::Step, *};
+use wgpu::CommandBuffer;
+
+// Re add type id here if needed later on for downcasting
+// or debug logging
+#[derive(Debug, Default)]
+pub struct StateStack {
+    stack: Vec<Box<dyn State>>,
+}
+// option 1: run each schedule individually drawback, non optimal schedule execution (possible to parellalize more)
+// option 2: all passes are resources -> foreground/background can be called many times without constructing more gpu resourcs
+// benefits: optimizied scheduling, no extra resource allocation on state transitions,
+// option 2 is implemented here
+impl StateStack {
+    #[must_use]
+    pub fn push<S: State + 'static>(
+        &mut self,
+        mut state: S,
+        world: &mut World,
+        resources: &mut Resources,
+        command_receivers: &mut Vec<Receiver<CommandBuffer>>,
+    ) -> Vec<Step> {
+        // initialize the new state
+        info!("Initializing state: {:?}", state);
+        state.on_init(world, resources, command_receivers);
+        info!("Pushing state: {:?}", state);
+        self.stack.push(Box::new(state));
+        self.calc_schedule_steps()
+    }
+
+    #[must_use]
+    pub fn push_all(
+        &mut self,
+        states: impl IntoIterator<Item = Box<dyn State>>,
+        world: &mut World,
+        resources: &mut Resources,
+        command_receivers: &mut Vec<Receiver<CommandBuffer>>,
+    ) -> Vec<Step> {
+        states.into_iter().for_each(|mut state| {
+            // initialize the new state
+            info!("Initializing state: {:?}", state);
+            state.on_init(world, resources, command_receivers);
+            info!("Pushing state: {:?}", state);
+            self.stack.push(state);
+        });
+        self.calc_schedule_steps()
+    }
+
+    #[must_use]
+    pub fn pop(&mut self, world: &mut World, resources: &mut Resources) -> Vec<Step> {
+        info!("Popping state");
+        if let Some(mut current_foreground) = self.stack.pop() {
+            info!("Destroying state previous head");
+            current_foreground.on_destroy(world, resources);
+        }
+        self.calc_schedule_steps()
+    }
+
+    pub fn states_mut<'a>(&'a mut self) -> impl Iterator<Item = &'a mut Box<dyn State + 'static>> {
+        self.stack.iter_mut()
+    }
+
+    fn calc_schedule_steps(&self) -> Vec<Step> {
+        if self.stack.is_empty() {
+            return Vec::new();
+        }
+        std::iter::once(self.stack.last().unwrap())
+            .map(|state| state.foreground_schedule())
+            .chain(
+                self.stack
+                    .iter()
+                    .rev()
+                    // skip foreground state
+                    .skip(1)
+                    .map(|state| state.background_schedule()),
+            )
+            .flat_map(|schedule| schedule.into_vec())
+            .collect::<Vec<Step>>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paste::paste;
+    macro_rules! create_test_state {
+        ($state_name:ident) => {
+            paste! {
+                #[derive(Debug)]
+                struct $state_name;
+
+                #[derive(Debug, Default)]
+                struct [<$state_name Resources>] {
+                    on_init: u32,
+                    background_resource: u32,
+                    foreground_resource: u32,
+                    on_destroy: u32,
+                }
+
+                #[system]
+                fn [<$state_name foreground>](#[resource] res: &mut [<$state_name Resources>]) {
+                    res.foreground_resource += 1;
+                }
+
+                #[system]
+                fn [<$state_name background>](#[resource] res: &mut [<$state_name Resources>]) {
+                    res.background_resource += 1;
+                }
+
+                impl State for $state_name {
+                    fn on_init(
+                        &mut self,
+                        _world: &mut World,
+                        resources: &mut Resources,
+                        _command_receivers: &mut Vec<Receiver<CommandBuffer>>,
+                    ) {
+                        let mut res = resources.get_mut::<[<$state_name Resources>]>().unwrap();
+                        res.on_init += 1;
+                    }
+
+                    fn on_tick(&mut self) -> crate::state::StateTransition {
+                        crate::state::StateTransition::Noop
+                    }
+
+                    fn on_destroy(&mut self, _world: &mut World, resources: &mut Resources) {
+                        let mut res = resources.get_mut::<[<$state_name Resources>]>().unwrap();
+                        res.on_destroy += 1;
+                    }
+
+                    fn background_schedule(&self) -> Schedule {
+                        Schedule::builder()
+                            .add_system([<$state_name background_system>]())
+                            .build()
+                    }
+
+                    fn foreground_schedule(&self) -> Schedule {
+                        Schedule::builder()
+                            .add_system([<$state_name foreground_system>]())
+                            .build()
+                    }
+                }
+            }
+        };
+    }
+
+    create_test_state!(StateA);
+    create_test_state!(StateB);
+    create_test_state!(StateC);
+
+    #[test]
+    fn test_push() {
+        let mut world = World::default();
+        let mut resources = Resources::default();
+        resources.insert(StateAResources::default());
+
+        let mut state_stack = StateStack::default();
+        let steps = state_stack.push(StateA, &mut world, &mut resources, &mut Vec::new());
+
+        let res = resources.get::<StateAResources>().unwrap();
+        assert_eq!(res.on_init, 1);
+        drop(res);
+
+        let mut schedule = Schedule::from(steps);
+        schedule.execute(&mut world, &mut resources);
+        let res = resources.get::<StateAResources>().unwrap();
+        assert_eq!(res.on_init, 1);
+        assert_eq!(res.foreground_resource, 1);
+        assert_eq!(res.background_resource, 0);
+        assert_eq!(res.on_destroy, 0);
+    }
+
+    #[test]
+    fn test_pop() {
+        let mut world = World::default();
+        let mut resources = Resources::default();
+        resources.insert(StateAResources::default());
+
+        let mut state_stack = StateStack::default();
+        let steps = state_stack.push(StateA, &mut world, &mut resources, &mut Vec::new());
+
+        let mut schedule = Schedule::from(steps);
+        schedule.execute(&mut world, &mut resources);
+
+        let _ = state_stack.pop(&mut world, &mut resources);
+
+        let res = resources.get::<StateAResources>().unwrap();
+        assert_eq!(res.on_init, 1);
+        assert_eq!(res.foreground_resource, 1);
+        assert_eq!(res.background_resource, 0);
+        assert_eq!(res.on_destroy, 1);
+    }
+
+    #[test]
+    fn test_transition() {
+        let mut world = World::default();
+        let mut resources = Resources::default();
+        resources.insert(StateAResources::default());
+        resources.insert(StateBResources::default());
+        resources.insert(StateCResources::default());
+
+        let mut state_stack = StateStack::default();
+        let steps = state_stack.push_all(
+            vec![
+                Box::new(StateC) as Box<dyn State>,
+                Box::new(StateB) as Box<dyn State>,
+                Box::new(StateA) as Box<dyn State>,
+            ],
+            &mut world,
+            &mut resources,
+            &mut Vec::new(),
+        );
+        let mut schedule = Schedule::from(steps);
+        schedule.execute(&mut world, &mut resources);
+
+        let res_a = resources.get::<StateAResources>().unwrap();
+        assert_eq!(res_a.on_init, 1);
+        assert_eq!(res_a.foreground_resource, 1);
+        assert_eq!(res_a.background_resource, 0);
+        assert_eq!(res_a.on_destroy, 0);
+
+        let res_b = resources.get::<StateBResources>().unwrap();
+        assert_eq!(res_b.on_init, 1);
+        assert_eq!(res_b.foreground_resource, 0);
+        assert_eq!(res_b.background_resource, 1);
+        assert_eq!(res_b.on_destroy, 0);
+
+        let res_c = resources.get::<StateCResources>().unwrap();
+        assert_eq!(res_c.on_init, 1);
+        assert_eq!(res_c.foreground_resource, 0);
+        assert_eq!(res_c.background_resource, 1);
+        assert_eq!(res_c.on_destroy, 0);
+        drop(res_a);
+        drop(res_b);
+        drop(res_c);
+
+        let steps = state_stack.pop(&mut world, &mut resources);
+        let mut schedule = Schedule::from(steps);
+        schedule.execute(&mut world, &mut resources);
+
+        let res_a = resources.get::<StateAResources>().unwrap();
+        assert_eq!(res_a.on_init, 1);
+        assert_eq!(res_a.foreground_resource, 1);
+        assert_eq!(res_a.background_resource, 0);
+        assert_eq!(res_a.on_destroy, 1);
+
+        let res_b = resources.get::<StateBResources>().unwrap();
+        assert_eq!(res_b.on_init, 1);
+        assert_eq!(res_b.foreground_resource, 1);
+        assert_eq!(res_b.background_resource, 1);
+        assert_eq!(res_b.on_destroy, 0);
+
+        let res_c = resources.get::<StateCResources>().unwrap();
+        assert_eq!(res_c.on_init, 1);
+        assert_eq!(res_c.foreground_resource, 0);
+        assert_eq!(res_c.background_resource, 2);
+        assert_eq!(res_c.on_destroy, 0);
+        drop(res_a);
+        drop(res_b);
+        drop(res_c);
+
+        let steps = state_stack.pop(&mut world, &mut resources);
+        let mut schedule = Schedule::from(steps);
+        schedule.execute(&mut world, &mut resources);
+        let res_a = resources.get::<StateAResources>().unwrap();
+        assert_eq!(res_a.on_init, 1);
+        assert_eq!(res_a.foreground_resource, 1);
+        assert_eq!(res_a.background_resource, 0);
+        assert_eq!(res_a.on_destroy, 1);
+
+        let res_b = resources.get::<StateBResources>().unwrap();
+        assert_eq!(res_b.on_init, 1);
+        assert_eq!(res_b.foreground_resource, 1);
+        assert_eq!(res_b.background_resource, 1);
+        assert_eq!(res_b.on_destroy, 1);
+
+        let res_c = resources.get::<StateCResources>().unwrap();
+        assert_eq!(res_c.on_init, 1);
+        assert_eq!(res_c.foreground_resource, 1);
+        assert_eq!(res_c.background_resource, 2);
+        assert_eq!(res_c.on_destroy, 0);
+    }
+}

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -10,7 +10,20 @@ use legion::{query::LayoutFilter, serialize::Canon, *};
 use serde::{de::DeserializeSeed, Deserialize, Serialize};
 
 use crate::components::{EntityType, Transform, Velocity};
+#[derive(Debug, Clone, Copy)]
+pub struct WindowSize {
+    pub physical_width: u32,
+    pub physical_height: u32,
+    pub scale_factor: f32,
+}
 
+impl WindowSize {
+    pub fn logical_size(&self) -> (u32, u32) {
+        let logical_width = self.physical_width as f32 / self.scale_factor;
+        let logical_height = self.physical_height as f32 / self.scale_factor;
+        (logical_width as u32, logical_height as u32)
+    }
+}
 #[derive(Debug)]
 pub struct Time {
     pub current_time: std::time::Instant,


### PR DESCRIPTION
It's implemented as a State stack where a state implements the State trait. You can push states on top of eachother and define behavior for the state that differs depending if it's a background state compared to a foreground state. It's also easy to remove states by popping the stack.

- `on_init`: contains state initialization, for example setting up render passes, loading assets etc. This is currently called when pushing a new state to the stack.
- `on_foreground_tick`: Called every game "tick" which currently is your frame rate but will probably be fixed and decoupled from frame rate in the near future. This is only called for the state which is in foreground. This method is also the way you transition between states. You return a StateTransition which determines if a new state should be pushed, the current should be popped or if nothing should happen.
- `on_resize`: Called for all states if the window is resized 
- `on_destroy`: Called if a state is popped of the stack, useful to clean up resources.
- `background_schedule`: Defines the schedule that should be ran when the state is in the background. Note this can be called multiple times so this should not modify anything in the state.
- `foreground_schedule`: Defines the schedule that should be ran when the state is in the foreground. Note this can be called multiple times so this should not modify anything in the state.